### PR TITLE
Add server-side JavaScript (i.e. nodejs) probe implementation

### DIFF
--- a/probes/js/node_probe.js
+++ b/probes/js/node_probe.js
@@ -1,0 +1,31 @@
+const process = require("process");
+const path = require("path");
+const fs = require("fs");
+
+/*
+** Updates the access and modified times of the probe file for this marker.
+** Async. No return value. Any errors swallowed and short-circuit as soon as possible.
+*/
+module.exports.probe = function(marker) {
+  const dir = process.env.SCYTHE_PROBE_DIR;
+  fs.stat(dir, (err, stats) => {
+    if (err == null && stats && stats.isDirectory()) fs.open(probeFileName(dir, marker), 'a', (err, fd) => {
+      if (err == null) fs.futimes(fd, posixNow(), posixNow(), function(){});
+    });
+  });
+}
+
+/*
+** Returns the full path of the probe file for this marker
+*/
+function probeFileName(dir, marker) {
+  return path.join(dir, marker + ".scythe_probe");
+}
+
+/*
+** Posix timestamps are *seconds* since epoch.
+** `Date.now()` returns milliseconds. Zero-shift truncates float to integer.
+*/
+function posixNow() {
+  return (Date.now() / 1000) >> 0;
+}

--- a/probes/js/test_node_probe.js
+++ b/probes/js/test_node_probe.js
@@ -1,0 +1,44 @@
+/*
+** Usage: `node test_node_probe`
+**
+** No test framework required.
+**
+** Due to the async and non-determinant nature of probe file updates, we impose an arbitrary delay to verify expected behaviour.
+** This could be made deterministic with a mock file system, but that is deemed to be not valuable at time of writing.
+*/
+
+const fs = require("fs");
+const scythe = require("./node_probe.js");
+var stats;
+
+process.env.SCYTHE_PROBE_DIR = "/tmp";
+scythe.probe("test-happy");
+
+process.env.SCYTHE_PROBE_DIR = "/";
+scythe.probe("test-no-access");
+
+process.env.SCYTHE_PROBE_DIR = "/dev/null";
+scythe.probe("test-not-dir");
+
+process.env.SCYTHE_PROBE_DIR = undefined;
+scythe.probe("test-no-env");
+
+
+const execs = require('child_process').execSync;
+execs("sleep 5");
+
+stats = fs.stat("/tmp/test-happy.scythe_probe", (err, stats) => {
+  console.log("test-happy " + stats.isFile());
+});
+
+stats = fs.stat("/test-no-access.scythe_probe", (err, stats) => {
+  console.log("test-no-access " + (err.code == "ENOENT"));
+});
+
+stats = fs.stat("/dev/null/test-not-dir.scythe_probe", (err, stats) => {
+  console.log("test-not-dir " + (err.code == "ENOTDIR"));
+});
+
+stats = fs.stat("test-no-env.scythe_probe", (err, stats) => {
+  console.log("test-no-env " + (err.code == "ENOENT"));
+});

--- a/probes/js/test_node_probe.js
+++ b/probes/js/test_node_probe.js
@@ -13,7 +13,8 @@ scythe.probe("test-happy", function(err) {
   if (!err) {
     fs.stat("/tmp/test-happy.scythe_probe", (err, stats) => {
       if (!err) {
-        console.log("test-happy " + stats.isFile());
+        timeDiff = (Math.abs(Date.now() - stats.mtime.getTime()) / 1000) >> 0;
+        console.log("test-happy " + (stats.isFile() && timeDiff <= 1)); // file must exist and mtime is within 1 seconds of "now"
         fs.unlink("/tmp/test-happy.scythe_probe", function(){});
       } else {
         console.log("test-happy " + err);
@@ -38,4 +39,3 @@ process.env.SCYTHE_PROBE_DIR = undefined;
 scythe.probe("test-no-env", function(err) {
   console.log("test-no-env " + (err && err.code == "ENOENT"));
 });
-

--- a/probes/js/test_node_probe.js
+++ b/probes/js/test_node_probe.js
@@ -3,42 +3,39 @@
 **
 ** No test framework required.
 **
-** Due to the async and non-determinant nature of probe file updates, we impose an arbitrary delay to verify expected behaviour.
-** This could be made deterministic with a mock file system, but that is deemed to be not valuable at time of writing.
 */
 
 const fs = require("fs");
 const scythe = require("./node_probe.js");
-var stats;
 
 process.env.SCYTHE_PROBE_DIR = "/tmp";
-scythe.probe("test-happy");
-
-process.env.SCYTHE_PROBE_DIR = "/";
-scythe.probe("test-no-access");
+scythe.probe("test-happy", function(err) {
+  if (!err) {
+    fs.stat("/tmp/test-happy.scythe_probe", (err, stats) => {
+      if (!err) {
+        console.log("test-happy " + stats.isFile());
+        fs.unlink("/tmp/test-happy.scythe_probe", function(){});
+      } else {
+        console.log("test-happy " + err);
+      }
+    });
+  } else {
+    console.log("test-happy " + err);
+  }
+});
 
 process.env.SCYTHE_PROBE_DIR = "/dev/null";
-scythe.probe("test-not-dir");
+scythe.probe("test-not-dir", function(err) {
+  console.log("test-not-dir " + (err && err.code == "ENOTDIR"));
+});
+
+process.env.SCYTHE_PROBE_DIR = "/";
+scythe.probe("test-no-access", function(err) {
+  console.log("test-no-access " + (err && err.code == "EACCES"));
+});
 
 process.env.SCYTHE_PROBE_DIR = undefined;
-scythe.probe("test-no-env");
-
-
-const execs = require('child_process').execSync;
-execs("sleep 5");
-
-stats = fs.stat("/tmp/test-happy.scythe_probe", (err, stats) => {
-  console.log("test-happy " + stats.isFile());
+scythe.probe("test-no-env", function(err) {
+  console.log("test-no-env " + (err && err.code == "ENOENT"));
 });
 
-stats = fs.stat("/test-no-access.scythe_probe", (err, stats) => {
-  console.log("test-no-access " + (err.code == "ENOENT"));
-});
-
-stats = fs.stat("/dev/null/test-not-dir.scythe_probe", (err, stats) => {
-  console.log("test-not-dir " + (err.code == "ENOTDIR"));
-});
-
-stats = fs.stat("test-no-env.scythe_probe", (err, stats) => {
-  console.log("test-no-env " + (err.code == "ENOENT"));
-});


### PR DESCRIPTION
Because @michaelfeathers asked so nicely this morning on his live video.

This implementation, like the other languages, is intended to get out of the way as soon as possible, and do no harm.

I have an excellent idea for a client-side JavaScript implementation. Stay tuned!